### PR TITLE
change nightly version number to yyyymmdd

### DIFF
--- a/.github/actions/get-next-package-version.js
+++ b/.github/actions/get-next-package-version.js
@@ -51,12 +51,12 @@ try {
   const nextVersionYear = nextVersionMonthDate.getFullYear().toString().slice(-2);
   const nextVersionMonth = nextVersionMonthDate.getMonth() + 1; // Convert back to 1-indexed
 
-  // Get current day
-  const day = new Date().getDate();
+  // Get current date string
+  const currentDate = new Date().toISOString().split('T')[0].replaceAll('-', '');
 
   switch (values.type) {
     case 'nightly': {
-      const newVersion = `${nextVersionYear}.${nextVersionMonth}.0-nightly.${day}`;
+      const newVersion = `${nextVersionYear}.${nextVersionMonth}.0-nightly.${currentDate}`;
       process.stdout.write(newVersion); // return the new version to stdout
       process.exit();
     }

--- a/upcoming-release-notes/5047.md
+++ b/upcoming-release-notes/5047.md
@@ -1,6 +1,6 @@
 ---
 category: Maintenance
-authors: [MikesGlitch]
+authors: [MikesGlitch, matt-fidd]
 ---
 
 Added a Git Workflow to publish edge NPM packages every night


### PR DESCRIPTION
Based on the branch before it was rebased, so v25.5.0 was most current

```sh
pangolin:actual:edge-npm-packages% node .github/actions/get-next-package-version.js -p packages/sync-server/package.json -t nightly
25.6.0-nightly.20250610%

pangolin:actual:edge-npm-packages% node .github/actions/get-next-package-version.js -p packages/sync-server/package.json -t hotfix
25.5.1%

pangolin:actual:edge-npm-packages% node .github/actions/get-next-package-version.js -p packages/sync-server/package.json -t monthly
25.6.0%
```

for https://github.com/actualbudget/actual/pull/5047